### PR TITLE
chore: upgrade eslint-config-adslot to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,9 +1334,9 @@
       }
     },
     "eslint-config-adslot": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-adslot/-/eslint-config-adslot-1.0.2.tgz",
-      "integrity": "sha512-GFV6wIEWo2MHRvQn7nUeDk8ylwA7XLKmv3jNxfTuIyMqbz2mY9tP+tFyR3rx77dmWttdq08Jjfnra2RwSltksQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-adslot/-/eslint-config-adslot-1.0.3.tgz",
+      "integrity": "sha512-mKZeO8GIThMX7j93lSWjdIX95wnygUn5ZLmUooqWqeYHjcokkW63rJwYstnyfI0f2pBaf+mg39wIW0SS1jIGgw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/eslint-plugin": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
-    "eslint-config-adslot": "^1.0.2",
+    "eslint-config-adslot": "^1.0.3",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0"
   },


### PR DESCRIPTION
Upgrade eslint-config-adslot to 1.0.3